### PR TITLE
TTWN Update

### DIFF
--- a/src/radautopy/radauto.py
+++ b/src/radautopy/radauto.py
@@ -49,7 +49,7 @@ def cli(ctx, config_file, verbose, disable_email):
     elif 'rss' == job_type:
         ctx.obj['remote'] = RadRSS(**config.rss)
     elif 'ttwn' == job_type:
-        ctx.obj['remote'] = TTWN(**config.ttwn, timestamp_dir = config.dirs['audio_tmp'])
+        ctx.obj['remote'] = TTWN(**config.ttwn)
 
 @cli.command()
 @click.option('-t', '--tries', type=int, default=1, help='define number of tries')

--- a/src/radautopy/radauto.py
+++ b/src/radautopy/radauto.py
@@ -24,7 +24,7 @@ logger = RadLogger(LOG_FILE).get_logger()
 
 @click.group()
 @click.option('-v', '--verbose', is_flag=True, help='enable verbose mode')
-@click.option('--disable_email', is_flag=True, help='disable email notification', default=True)
+@click.option('--disable_email', is_flag=True, help='test disable email notification', default=True)
 @click.argument('config_file')
 @click.pass_context
 def cli(ctx: click.Context, config_file: str, verbose: bool, disable_email:bool) -> None:

--- a/src/radautopy/radauto.py
+++ b/src/radautopy/radauto.py
@@ -1,6 +1,5 @@
 import click
 from pathlib import Path
-from time import sleep
 
 from .utils.config import LOG_DIR
 from .utils.config.config import ConfigJSON

--- a/src/radautopy/radauto.py
+++ b/src/radautopy/radauto.py
@@ -27,7 +27,7 @@ logger = RadLogger(LOG_FILE).get_logger()
 @click.option('--disable_email', is_flag=True, help='disable email notification', default=True)
 @click.argument('config_file')
 @click.pass_context
-def cli(ctx, config_file, verbose, disable_email):
+def cli(ctx: click.Context, config_file: str, verbose: bool, disable_email:bool) -> None:
     if verbose:
         logger = RadLogger(LOG_FILE, verbose=True).get_logger()
 
@@ -54,23 +54,23 @@ def cli(ctx, config_file, verbose, disable_email):
 @click.option('-t', '--tries', type=int, default=1, help='define number of tries')
 @click.option('-s', '--sleep_timer', type=int, default=1200, help='define number of seconds between tries')
 @click.pass_context
-def news(ctx, tries, sleep_timer):
+def news(ctx: click.Context, tries: int, sleep_timer: int) -> None:
     perform_news(ctx.obj.get('config'), ctx.obj.get('mailer'), ctx.obj.get('email_bool'), ctx.obj.get('remote'), tries, sleep_timer)
 
 @cli.command()
 @click.pass_context
-def standard(ctx):
+def standard(ctx: click.Context) -> None:
     perform_standard(ctx.obj.get('config'), ctx.obj.get('mailer'), ctx.obj.get('email_bool'), ctx.obj.get('remote'))
 
 @cli.command()
 @click.option('-t', '--threshold', type=int, default = -60, help='define db threshold for silence split')
 @click.option('-d', '--duration', type=int, default = 15, help='silence duration in seconds')
 @click.pass_context
-def split_single(ctx, threshold, duration):
+def split_single(ctx: click.Context, threshold: int, duration: int) -> None:
     perform_split_single(ctx.obj.get('config'), ctx.obj.get('mailer'), ctx.obj.get('email_bool'), ctx.obj.get('remote'), threshold, duration)
 
 @cli.command()
 @click.pass_context
-def ttwn(ctx):
+def ttwn(ctx: click.Context) -> None:
     perform_ttwn(ctx.obj.get('config'), ctx.obj.get('mailer'), ctx.obj.get('email_bool'), ctx.obj.get('remote'))
 

--- a/src/radautopy/radauto.py
+++ b/src/radautopy/radauto.py
@@ -41,7 +41,7 @@ def cli(ctx: click.Context, config_file: str, verbose: bool, disable_email:bool)
     job_type = config.job['job_type']
     if 'ftp' == job_type:
         ctx.obj['remote'] = RadFTP(**config.FTP)
-    if 'sftp' == job_type:
+    elif 'sftp' == job_type:
         ctx.obj['remote'] = RadSFTP(**config.SFTP)
     elif 'cloud' == job_type:
         ctx.obj['remote'] = RadCloud(**config.cloud)

--- a/src/radautopy/radauto_config.py
+++ b/src/radautopy/radauto_config.py
@@ -102,7 +102,7 @@ def validate(config_file):
         elif 'rss' == config.job['job_type']:
             remote = RadRSS(**config.rss)
         elif 'ttwn' == config.job['job_type']:
-            remote = TTWN(**config.ttwn, timestamp_dir = config.dirs['audio_tmp'])
+            remote = TTWN(**config.ttwn)
 
         remote.validate()
 

--- a/src/radautopy/runners/news.py
+++ b/src/radautopy/runners/news.py
@@ -5,12 +5,20 @@ from time import sleep
 
 from . import LOGGER_NAME
 from ..utils.audio import AudioFile
-from ..utils.config.config import ConfigJson
+from ..utils.config.config import ConfigJSON
 from ..utils.mail import RadMail
 
 logger = logging.getLogger(LOGGER_NAME)
 
-def perform_news(config: ConfigJson, mailer: RadMail, email_bool: bool, remote, tries: int, sleep_timer: int) -> None:
+def perform_news(
+        config: ConfigJSON,
+        mailer: RadMail,
+        email_bool: bool,
+        remote,
+        tries: int,
+        sleep_timer: int
+    ) -> None:
+
     tracks = config.filemap
     while tracks and tries > 0:
         mailer.message = ""

--- a/src/radautopy/runners/news.py
+++ b/src/radautopy/runners/news.py
@@ -5,10 +5,12 @@ from time import sleep
 
 from . import LOGGER_NAME
 from ..utils.audio import AudioFile
+from ..utils.config.config import ConfigJson
+from ..utils.mail import RadMail
 
 logger = logging.getLogger(LOGGER_NAME)
 
-def perform_news(config, mailer, email_bool, remote, tries, sleep_timer):
+def perform_news(config: ConfigJson, mailer: RadMail, email_bool: bool, remote, tries: int, sleep_timer: int) -> None:
     tracks = config.filemap
     while tracks and tries > 0:
         mailer.message = ""

--- a/src/radautopy/runners/split_single.py
+++ b/src/radautopy/runners/split_single.py
@@ -1,8 +1,10 @@
 import click
 import shutil
 from ..utils.audio import AudioFile
+from ..utils.config.config import ConfigJSON
+from ..utils.mail import RadMail
 
-def perform_split_single(config, mailer, email_bool, remote, threshold, duration):
+def perform_split_single(config: ConfigJSON, mailer: RadMail, email_bool: bool, remote, threshold: int, duration: int) -> None:
     local_file = AudioFile(remote.download(config.dirs['download_dir']), config.dirs['audio_tmp'])
     mailer.p(f'Download Success {local_file.input_file.name = }')
     split_audio = local_file.split_silence(threshold, duration)

--- a/src/radautopy/runners/split_single.py
+++ b/src/radautopy/runners/split_single.py
@@ -4,7 +4,15 @@ from ..utils.audio import AudioFile
 from ..utils.config.config import ConfigJSON
 from ..utils.mail import RadMail
 
-def perform_split_single(config: ConfigJSON, mailer: RadMail, email_bool: bool, remote, threshold: int, duration: int) -> None:
+def perform_split_single(
+        config: ConfigJSON,
+        mailer: RadMail,
+        email_bool: bool,
+        remote,
+        threshold: int,
+        duration: int
+    ) -> None:
+
     local_file = AudioFile(remote.download(config.dirs['download_dir']), config.dirs['audio_tmp'])
     mailer.p(f'Download Success {local_file.input_file.name = }')
     split_audio = local_file.split_silence(threshold, duration)

--- a/src/radautopy/runners/standard.py
+++ b/src/radautopy/runners/standard.py
@@ -5,7 +5,7 @@ from ..utils.audio import AudioFile
 
 logger = logging.getLogger(LOGGER_NAME)
 
-def perform_standard(config, mailer, email_bool, remote):
+def perform_standard(config, mailer, email_bool: bool, remote) -> None:
     config.concat_directories_filemap()
     downloads = [(x['input_file'].name, x['input_file']) for x in config.filemap]
     logger.info(f'{downloads = }')

--- a/src/radautopy/runners/standard.py
+++ b/src/radautopy/runners/standard.py
@@ -7,7 +7,13 @@ from ..utils.mail import RadMail
 
 logger = logging.getLogger(LOGGER_NAME)
 
-def perform_standard(config: ConfigJSON, mailer: RadMail, email_bool: bool, remote) -> None:
+def perform_standard(
+        config: ConfigJSON,
+        mailer: RadMail,
+        email_bool: bool,
+        remote
+    ) -> None:
+
     config.concat_directories_filemap()
     downloads = [(x['input_file'].name, x['input_file']) for x in config.filemap]
     logger.info(f'{downloads = }')

--- a/src/radautopy/runners/standard.py
+++ b/src/radautopy/runners/standard.py
@@ -2,10 +2,12 @@ import logging
 
 from . import LOGGER_NAME
 from ..utils.audio import AudioFile
+from ..utils.config.config import ConfigJSON
+from ..utils.mail import RadMail
 
 logger = logging.getLogger(LOGGER_NAME)
 
-def perform_standard(config, mailer, email_bool: bool, remote) -> None:
+def perform_standard(config: ConfigJSON, mailer: RadMail, email_bool: bool, remote) -> None:
     config.concat_directories_filemap()
     downloads = [(x['input_file'].name, x['input_file']) for x in config.filemap]
     logger.info(f'{downloads = }')

--- a/src/radautopy/runners/ttwn.py
+++ b/src/radautopy/runners/ttwn.py
@@ -10,13 +10,19 @@ from . import LOGGER_NAME
 
 logger = logging.getLogger(LOGGER_NAME)
 
-def perform_ttwn(config: ConfigJSON, mailer: RadMail, email_bool: bool, remote) -> None:
+def perform_ttwn(
+        config: ConfigJSON,
+        mailer: RadMail,
+        email_bool: bool,
+        remote
+    ) -> None:
+
     try:
         file_urls = remote.get_file_urls()
     except Exception as e:
         logger.critical(f"Could not get file list: {e}")
         mailer.p('Could not get file list')
-        mailer.send_email(alt_subject='TTWN: An error occurred')
+        mailer.send_mail(alt_subject='TTWN: An error occurred')
         return
 
     if not file_urls:

--- a/src/radautopy/runners/ttwn.py
+++ b/src/radautopy/runners/ttwn.py
@@ -9,28 +9,28 @@ from . import LOGGER_NAME
 logger = logging.getLogger(LOGGER_NAME)
 
 def perform_ttwn(config, mailer, email_bool, remote):
-    timestamp = remote.probe_timestamp()
-    if handle_status_code(remote.manifest.status_code, mailer):
-        try:
-            url = remote.get_manifest(timestamp)
-            logger.info('got manifest')
-        except:
-            logger.critical('could not get manifest')
-            mailer.p('Could not get manifest')
-            mailer.send_mail(alt_subject = 'An error occurred')
+    try:
+        file_urls = remote.get_file_urls()
+    except Exception as e:
+        logger.critical(f"Could not get file list: {e}")
+        mailer.p('Could not get file list')
+        mailer.send_email(alt_subject='TTWN: An error occurred')
+        return
 
-    remote_audio = remote.get_remote(url)
+    if not file_urls:
+        logger.info('No new files available')
+        return
+
     config.concat_directories_filemap()
     track = config.filemap[0]
-    if handle_status_code(remote_audio.status_code, mailer):
-        if remote.download_file(remote_audio, track['input_file']):
-            local_track = AudioFile(track['input_file'], track['output_file'])
-            local_track.apply_metadata(track['artist'], track['title'])
-            local_track.move()
-            logger.info('successfully moved audio')
-        else:
-            mailer.p('Something went wrong')
-            mailer.send_mail()
+    if remote.download_file(file_urls[0], track['input_file']):
+        local_track = AudioFile(track['input_file'], track['output_file'])
+        local_track.apply_metadata(track['artist'], track['title'])
+        local_track.move()
+        logger.info('successfully moved audio')
+    else:
+        mailer.p('Download failed')
+        mailer.send_mail(alt_subject='TTWN: An error occurred')
 
 
 

--- a/src/radautopy/runners/ttwn.py
+++ b/src/radautopy/runners/ttwn.py
@@ -2,13 +2,15 @@ import logging
 
 from ..utils.audio import AudioFile
 from ..utils.config import ROOT_DIR
+from ..utils.config.config import ConfigJSON
+from ..utils.mail import RadMail
 from ..utils.utilities import handle_status_code
 
 from . import LOGGER_NAME
 
 logger = logging.getLogger(LOGGER_NAME)
 
-def perform_ttwn(config, mailer, email_bool, remote):
+def perform_ttwn(config: ConfigJSON, mailer: RadMail, email_bool: bool, remote) -> None:
     try:
         file_urls = remote.get_file_urls()
     except Exception as e:

--- a/src/radautopy/utils/audio.py
+++ b/src/radautopy/utils/audio.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import ffmpeg
 import hashlib

--- a/src/radautopy/utils/audio.py
+++ b/src/radautopy/utils/audio.py
@@ -42,7 +42,7 @@ class AudioFile:
             return None
 
     @output_file.setter
-    def output_file(self, output_file: pathlib.Path | str) -> None:
+    def output_file(self, output_file: pathlib.Path | str | None) -> None:
         if output_file is not None:
             output_file = self.force_path(output_file)
             if output_file.is_dir():
@@ -59,7 +59,7 @@ class AudioFile:
         else:
             return f
 
-    def _create_output(self, new_filename: pathlib.Path | str = None) -> pathlib.Path:
+    def _create_output(self, new_filename: pathlib.Path | str | None = None) -> pathlib.Path:
         if not hasattr(self, '_output_file') and not new_filename:
             raise NameError("Either an output_file or a new_filename must be specified")
         elif not hasattr(self, '_output_file') or new_filename:
@@ -73,7 +73,7 @@ class AudioFile:
         else:
             return self.input_file
 
-    def _logged_popen(self, cmd_line, *args, **kwargs):
+    def _logged_popen(self, cmd_line: list[str], *args, **kwargs) -> subprocess.Popen:
         logger.debug(f'Running command: {subprocess.list2cmdline(cmd_line)}')
         return subprocess.Popen(cmd_line, *args, **kwargs)
 
@@ -84,7 +84,7 @@ class AudioFile:
         new_wav = NewCart(self.input_file, artist, title)
         wav.write_copy(new_wav)
 
-    def convert(self) -> pathlib.Path:
+    def convert(self) -> None:
         output = pathlib.Path(self.input_file.with_stem(self.input_file.stem + '_CONVERTING').with_suffix('.wav'))
         converted = str(self.input_file.with_suffix('.wav'))
         err, out = (ffmpeg
@@ -101,7 +101,7 @@ class AudioFile:
         self.input_file = converted
         logger.debug('move complete')
 
-    def analyse(self, blocksize: int = 65536, apply_input: bool = True) -> None:
+    def analyse(self, blocksize: int = 65536, apply_input: bool = True) -> str:
         audio = self._check_output(apply_input)
         logger.debug(f'analysing audio {audio}')
         hasher = hashlib.sha256()
@@ -118,13 +118,13 @@ class AudioFile:
         shutil.copy(audio_in, audio_copy)
         logger.debug(f'Copied {audio_in} to {audio_copy}')
 
-    def move(self, new_filename: pathlib.Path | str = None, apply_input: bool = True) -> None:
+    def move(self, new_filename: pathlib.Path | str | None = None, apply_input: bool = True) -> None:
         audio_in = self._check_output(apply_input)
         audio_out = self._create_output(new_filename)
         shutil.move(audio_in, audio_out)
         logger.debug(f'Moved {audio_in} to {audio_out}')
 
-    def split_silence(self, threshold: int = -60, duration: int = 10) -> list:
+    def split_silence(self, threshold: int = -60, duration: int = 10) -> list["AudioFile"]:
         silence_start_re = re.compile(r' silence_start: (?P<start>[0-9]+(\.?[0-9]*))$')
         silence_end_re = re.compile(r' silence_end: (?P<end>[0-9]+(\.?[0-9]*)) ')
         total_duration_re = re.compile(r'size[^ ]+ time=(?P<hours>[0-9]{2}):(?P<minutes>[0-9]{2}):(?P<seconds>[0-9\.]{5}) bitrate=')

--- a/src/radautopy/utils/baseargs.py
+++ b/src/radautopy/utils/baseargs.py
@@ -7,7 +7,7 @@ from . import LOGGER_NAME
 logger = logging.getLogger(LOGGER_NAME)
 
 class BaseArgs:
-    def __init__(self, varis: dict, runner_args: list[tuple] = None) -> None:
+    def __init__(self, varis: dict, runner_args: list[tuple] | None = None) -> None:
         program, helptext = varis.values()
         helptext = helptext + "\nConfig files are stored in ~/radautopy/config by default."
         self.validators: list = []
@@ -32,11 +32,11 @@ class BaseArgs:
         validate = subparsers.add_parser('validate')
         validate.add_argument('-l', '--list_remote', help='list remote files.', action='store_true')
 
-    def get_args(self) -> argparse.ArgumentParser:
+    def get_args(self) -> argparse.Namespace:
         self.args = self.parser.parse_args()
         return self.args
 
-    def builtins(self):
+    def builtins(self) -> None:
         if self.args.edit_config:
             self.args.config.edit_config()
 

--- a/src/radautopy/utils/baseargs.py
+++ b/src/radautopy/utils/baseargs.py
@@ -1,9 +1,6 @@
 import argparse
 import logging
 import pathlib
-import traceback
-
-from typing import Callable
 
 from . import LOGGER_NAME
 

--- a/src/radautopy/utils/cloud.py
+++ b/src/radautopy/utils/cloud.py
@@ -19,7 +19,7 @@ class RadCloud:
         rclone.copyto(f'{self.full_path}/{filename}', str(destination))
         logger.info(f'Successful download {filename} to {destination}')
 
-    def download_files(self, file_map: list[tuple]) -> None:
+    def download_files(self, file_map: list[tuple[str, pathlib.Path | str]]) -> None:
         for f in file_map:
             remote, local = f
             self.download(remote, local)

--- a/src/radautopy/utils/config/__init__.py
+++ b/src/radautopy/utils/config/__init__.py
@@ -91,7 +91,6 @@ TTWN_CONFIG = {
     "ttwn": {
         "url": str,
         "affiliate": str,
-        "username": str,
-        "password": str
+        "api_key": str
     }
 }

--- a/src/radautopy/utils/config/config.py
+++ b/src/radautopy/utils/config/config.py
@@ -2,15 +2,12 @@ import json
 import logging
 import pathlib
 
-from copy import deepcopy, copy
-from tabulate import tabulate
+from copy import deepcopy
 
 from . import CONFIG_DIR, LOGGER_NAME, EMAIL_CONFIG, DEFAULT_DIRS, DEFAULT_FILEMAP
 from .replace_fillers import ReplaceFillers
-from ..utilities import make_dirs, SafeDict
 
 logger = logging.getLogger(LOGGER_NAME)
-
 
 class ConfigJSON:
     def __init__(self, config_file: str | None = None) -> None:

--- a/src/radautopy/utils/config/config.py
+++ b/src/radautopy/utils/config/config.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(LOGGER_NAME)
 
 
 class ConfigJSON:
-    def __init__(self, config_file: str = None) -> None:
+    def __init__(self, config_file: str | None = None) -> None:
         self.email_config: pathlib.Path = pathlib.Path(CONFIG_DIR, "email.json")
         if self.email_config.exists():
             self.email_dict = self._parse_json(self.email_config)
@@ -37,7 +37,7 @@ class ConfigJSON:
         except Exception as e:
             logger.exception(e)
 
-    def concat_directories_filemap(self):
+    def concat_directories_filemap(self) -> None:
         for i, track in enumerate(self.filemap):
             self.filemap[i]['input_file'] = pathlib.Path(self.dirs['download_dir'], track['input_file'])
             self.filemap[i]['output_file'] = pathlib.Path(self.dirs['export_dir'], track['output_file'])

--- a/src/radautopy/utils/config/config.py
+++ b/src/radautopy/utils/config/config.py
@@ -1,4 +1,3 @@
-import click
 import json
 import logging
 import pathlib

--- a/src/radautopy/utils/config/config_modify.py
+++ b/src/radautopy/utils/config/config_modify.py
@@ -1,5 +1,4 @@
 import click
-import datetime
 import json
 import pathlib
 import subprocess

--- a/src/radautopy/utils/config/config_modify.py
+++ b/src/radautopy/utils/config/config_modify.py
@@ -8,12 +8,24 @@ from copy import copy
 from tabulate import tabulate
 from crontab import CronTab
 
-from . import CONFIG_DIR, EMAIL_CONFIG, DEFAULT_DIRS, DEFAULT_FILEMAP, CLOUD_CONFIG, JOB_METADATA, FTP_CONFIG, SFTP_CONFIG, RSS_CONFIG, TTWN_CONFIG
+from . import (
+        CONFIG_DIR,
+        EMAIL_CONFIG,
+        DEFAULT_DIRS,
+        DEFAULT_FILEMAP,
+        CLOUD_CONFIG,
+        JOB_METADATA,
+        FTP_CONFIG,
+        SFTP_CONFIG,
+        RSS_CONFIG,
+        TTWN_CONFIG,
+)
+
 from .config import ConfigJSON
 from .replace_fillers import ReplaceFillers
 from ..utilities import make_dirs, SafeDict
 
-def calculate_values(iterator: int, segments: int) -> tuple:
+def calculate_values(iterator: int, segments: int) -> tuple[int, int]:
     hour = (iterator - 1) // segments + 1
     segment = (iterator - 1) % segments + 1
     return hour, segment
@@ -75,7 +87,7 @@ class ConfigModify:
         conf = self.set_interactive(config)
         self.save_config(conf, self.email_config)
 
-    def set_config(self, config: dict = None) -> None:
+    def set_config(self, config: dict | None = None) -> None:
         if config is None:
             config = self.config_dict
         else:

--- a/src/radautopy/utils/config/config_modify.py
+++ b/src/radautopy/utils/config/config_modify.py
@@ -110,7 +110,7 @@ class ConfigModify:
 
 
                     if 'job_type' in subkey:
-                        skel[key][subkey] = click.prompt(f'Define {subkey}:', type=click.Choice(['ftp', 'cloud', 'rss', 'ttwn']), default=subval)
+                        skel[key][subkey] = click.prompt(f'Define {subkey}:', type=click.Choice(['ftp', 'sftp', 'cloud', 'rss', 'ttwn']), default=subval)
                     elif 'job_runner' in subkey:
                         skel[key][subkey] = click.prompt(f'Define {subkey}:', type=click.Choice(['news', 'standard', 'split_single', 'ttwn']), default=subval)
                     else:

--- a/src/radautopy/utils/ftp.py
+++ b/src/radautopy/utils/ftp.py
@@ -15,7 +15,7 @@ class RadFTP:
         self.server = server
         self.username = username
         self.password = password
-        self.pasv = bool
+        self.pasv = pasv
         self.directory = directory
 
     def do_action(self, function, pasv: bool = True, *args, **kwargs):

--- a/src/radautopy/utils/ftp.py
+++ b/src/radautopy/utils/ftp.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(LOGGER_NAME)
 
 
 class RadFTP:
-    def __init__(self, server: str, username: str, password: str, pasv: bool, directory: str = None) -> None:
+    def __init__(self, server: str, username: str, password: str, pasv: bool, directory: str | None = None) -> None:
         self.server = server
         self.username = username
         self.password = password
@@ -27,21 +27,7 @@ class RadFTP:
                 self.ftp.cwd(self.directory)
             return function(*args, **kwargs)
 
-    def validate(self) -> None:
-        click.echo('~~ FTP Settings ~~')
-        click.echo(f'server: {self.server}')
-        click.echo(f'username: {self.username}')
-        click.echo(f'password: {self.password}')
-        click.echo(f'directory: {self.directory}')
-        try:
-            files = self.do_action(self.list_remote)
-            for f in files:
-                click.echo(f)
-            click.echo('~~ FTP Connection success! ~~')
-        except:
-            click.echo('~~ FTP Connection Failed! ~~')
-
-    def list_remote(self, filename: str = None) -> list:
+    def list_remote(self, filename: str | None = None) -> list[str]:
         files = [] if filename is not None else ""
         try:
             if filename is not None:
@@ -62,15 +48,29 @@ class RadFTP:
 
         return files
 
-    def download_file(self, remote_file: str, local_file: pathlib.Path | str):
+    def download_file(self, remote_file: str, local_file: pathlib.Path | str) -> None:
         self.ftp.nlst(remote_file)
         with open(local_file, 'wb') as f:
             self.ftp.retrbinary('RETR ' + remote_file, f.write, 1024)
 
         logger.info(f"Downloaded {remote_file} as {local_file}")
 
-    def download_files(self, file_map: list[tuple]):
+    def download_files(self, file_map: list[tuple[str, pathlib.Path | str]]) -> None:
         for f in file_map:
             remote, local = f
             self.do_action(self.download_file, remote_file=remote, local_file=local)
+
+    def validate(self) -> None:
+        click.echo('~~ FTP Settings ~~')
+        click.echo(f'server: {self.server}')
+        click.echo(f'username: {self.username}')
+        click.echo(f'password: {self.password}')
+        click.echo(f'directory: {self.directory}')
+        try:
+            files = self.do_action(self.list_remote)
+            for f in files:
+                click.echo(f)
+            click.echo('~~ FTP Connection success! ~~')
+        except:
+            click.echo('~~ FTP Connection Failed! ~~')
 

--- a/src/radautopy/utils/ftp.py
+++ b/src/radautopy/utils/ftp.py
@@ -1,6 +1,5 @@
 import click
 import logging
-import traceback
 import pathlib
 
 from ftplib import FTP, error_perm

--- a/src/radautopy/utils/log_setup.py
+++ b/src/radautopy/utils/log_setup.py
@@ -7,7 +7,7 @@ from logging.handlers import RotatingFileHandler
 from . import LOGGER_NAME
 from .utilities import make_dirs
 
-def get_logger(logger: str = LOGGER_NAME) -> None:
+def get_logger(logger: str = LOGGER_NAME) -> logging.Logger:
     return logging.getLogger(logger)
 
 
@@ -77,7 +77,7 @@ class RadLogger:
     def get_logger(logger_name: str = LOGGER_NAME) -> logging.Logger:
         return logging.getLogger(logger_name)
 
-    def set_level(self, level):
+    def set_level(self, level: int) -> None:
         self.logger.setLevel(level)
 
 

--- a/src/radautopy/utils/log_setup.py
+++ b/src/radautopy/utils/log_setup.py
@@ -1,9 +1,6 @@
-import configparser
 import logging
 import logging.config
-import os
 import pathlib
-import traceback
 
 from logging.handlers import RotatingFileHandler
 

--- a/src/radautopy/utils/mail.py
+++ b/src/radautopy/utils/mail.py
@@ -26,7 +26,7 @@ class Attachment:
             self.mime_type = self.get_mime(subtype)
             self.subtype = subtype
 
-    def get_mime(self, mime_type: str) -> MIMEAudio | MIMEApplication:
+    def get_mime(self, mime_type: str) -> type[MIMEAudio] | type[MIMEApplication]:
         if mime_type == "mp3":
             logger.debug(f"Using MIMEaudio")
             return MIMEAudio

--- a/src/radautopy/utils/mail.py
+++ b/src/radautopy/utils/mail.py
@@ -1,6 +1,5 @@
 import logging
 import smtplib
-import traceback
 import pathlib
 
 from dataclasses import dataclass, field

--- a/src/radautopy/utils/rss.py
+++ b/src/radautopy/utils/rss.py
@@ -1,7 +1,6 @@
 import click
 import feedparser
 import logging
-import lxml
 import requests
 import wget
 

--- a/src/radautopy/utils/rss.py
+++ b/src/radautopy/utils/rss.py
@@ -15,7 +15,7 @@ class RadRSS:
     def __init__(self, url: str) -> None:
         self.url = url
 
-    def get_rss_entry(self):
+    def get_rss_entry(self) -> None:
         logger.info(f'Traversing the RSS feed: {self.url}')
         feed = feedparser.parse(self.url)
         if feed.status != 200 and feed.status != 302:
@@ -28,7 +28,7 @@ class RadRSS:
 
         self.entry = newest_entry
 
-    def get_download_link(self):
+    def get_download_link(self) -> None:
         try:
             entry_page = requests.get(self.entry)
         except Exception as e:
@@ -54,7 +54,7 @@ class RadRSS:
         self.download_link = mp3_link
 
 
-    def download(self, download_dir):
+    def download(self, download_dir: str) -> str:
         self.get_rss_entry()
         self.get_download_link()
         try:
@@ -66,10 +66,10 @@ class RadRSS:
             logger.exception(e)
             raise
 
-    def download_files(self):
+    def download_files(self) -> None:
         pass
 
-    def validate(self):
+    def validate(self) -> None:
         click.echo(f'Attempting {self.url = }')
         page = requests.get(self.url)
         if page.status_code != 200 and page.status_code != 302:

--- a/src/radautopy/utils/sftp.py
+++ b/src/radautopy/utils/sftp.py
@@ -1,6 +1,5 @@
 import click
 import logging
-import traceback
 import pathlib
 
 import paramiko

--- a/src/radautopy/utils/sftp.py
+++ b/src/radautopy/utils/sftp.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(LOGGER_NAME)
 
 
 class RadSFTP:
-    def __init__(self, server: str, username: str, password: str, directory: str = None) -> None:
+    def __init__(self, server: str, username: str, password: str, directory: str | None = None) -> None:
         self.server = server
         self.username = username
         self.password = password
@@ -43,7 +43,7 @@ class RadSFTP:
         except:
             click.echo('~~ SFTP Connection Failed! ~~')
 
-    def list_remote(self, filename: str = None) -> list:
+    def list_remote(self, filename: str | None = None) -> list[str]:
         files = []
         try:
             files = self.sftp.listdir(path='.')
@@ -58,7 +58,7 @@ class RadSFTP:
         self.sftp.get(remote_file, local_file)
         logger.info(f"Downloaded {remote_file} as {local_file}")
 
-    def download_files(self, file_map: list[tuple]) -> None:
+    def download_files(self, file_map: list[tuple[str, pathlib.Path | str]]) -> None:
         for f in file_map:
             remote, local = f
             self.do_action(self.download_file, remote_file=remote, local_file=local)

--- a/src/radautopy/utils/ttwn.py
+++ b/src/radautopy/utils/ttwn.py
@@ -15,7 +15,7 @@ class TTWN:
         self.api_key = api_key
         self.headers = {
                 "X-API-Key": api_key,
-                "User-Agent": "tten_download_script_radautopy"
+                "User-Agent": "ttwn_download_script_radautopy"
         }
 
     def get_file_urls(self) -> list[str]:

--- a/src/radautopy/utils/ttwn.py
+++ b/src/radautopy/utils/ttwn.py
@@ -62,6 +62,14 @@ class TTWN:
             return False
 
     def validate(self):
-        print(f'{self.url = }')
+        """Test the API connection."""
+        url = f"{self.url}/audio/{self.affiliate}/newFiles"
+        response = requests.get(url, headers=self.headers, timeout=30)
+        print(f"Status: {response.status_code}")
+        if response.status_code == 200:
+            lines = [l for l in response.text.splitlines() if l.strip()]
+            print(f"Files available: {len(lines)}")
+        else:
+            print(f"Error: {response.text}")
 
 

--- a/src/radautopy/utils/ttwn.py
+++ b/src/radautopy/utils/ttwn.py
@@ -3,13 +3,7 @@ import pathlib
 import requests
 import os
 
-from requests.auth import HTTPBasicAuth
-from datetime import datetime
-
 from . import LOGGER_NAME
-from .utilities import make_dirs
-from .config import ROOT_DIR
-
 
 logger = logging.getLogger(LOGGER_NAME)
 

--- a/src/radautopy/utils/ttwn.py
+++ b/src/radautopy/utils/ttwn.py
@@ -15,65 +15,48 @@ logger = logging.getLogger(LOGGER_NAME)
 
 
 class TTWN:
-    def __init__(self, url: str, affiliate: str, username: str, password: str, timestamp_dir: pathlib.Path) -> None:
+    def __init__(self, url: str, affiliate: str, api_key: str) -> None:
         self.url = url
         self.affiliate = affiliate
-        self.username = username
-        self.password = password
-        self.timestamp_dir = pathlib.Path(timestamp_dir)
-        self.remote_date_format = "%a, %d %b %Y %H:%M:%S GMT"
-        self.local_date_format = "%Y%m%d%H%M%S"
+        self.api_key = api_key
+        self.headers = {
+                "X-API-Key": api_key,
+                "User-Agent": "tten_download_script_radautopy"
+        }
 
-        self.manifest = self.get_remote(os.path.join(self.url, self.affiliate, 'filemanifest.txt'))
+    def get_file_urls(self) -> list[str]:
+        """Fetch the list of new file URLs from the API.
 
+        Returns a list of download URLs (one per file), or an empty list if there are no new files.
+        """
+        url = f"{self.url}/audio/{self.affiliate}/newFiles"
+        response = requests.get(url, headers = self.headers, timeout = 30)
+        response.raise_for_status()
 
-    def probe_timestamp(self, new_timestamp: str = None) -> str:
-        existing_timestamp = [x for x in self.timestamp_dir.glob('*.timestamp')]
+        return [line.strip() for lin in response.text.splitlines() if line.strip()]
 
-        if new_timestamp == None and not existing_timestamp:
-            default_timestamp = "20220325064459"
-            pathlib.Path(self.timestamp_dir, f'{default_timestamp}.timestamp').touch()
-            return default_timestamp
-        elif new_timestamp == None and existing_timestamp:
-            return existing_timestamp[0].stem
-        else:
-            existing_timestamp[0].unlink()
-            pathlib.Path(self.timestamp_dir, f'{new_timestamp}.timestamp').touch()
-            return new_timestamp
+    def download_file(self, file_url: str, local_path) -> bool:
+        """Download an audio file from the API.
 
-    def header_timestamp(self, req):
-        return datetime.strptime(
-                req.headers['last-modified'],
-                self.remote_date_format
-            ).strftime(
-                self.local_date_format
-            )
+        The API returns a 302 redirect to a signed CloudFront URL.
+        requests.get() follows this redirect automatically.
 
-    def get_remote(self, url):
-        return requests.get(url, auth=HTTPBasicAuth(self.username, self.password), timeout=20)
-
-    def get_manifest(self, timestamp: str) -> str:
-        modified = self.header_timestamp(self.manifest)
-
-        if modified > timestamp:
-            lines = self.manifest.iter_lines(decode_unicode=True)
-            for line in lines:
-                if "url" in line:
-                    url = line.split('=')[1].replace('"', '').strip()
-                    return url
-        else:
-            raise
-
-
-    def download_file(self, remote, local):
+        Returns True on success, False on failure.
+        """
         try:
-            with open(local, 'wb') as audio:
-                audio.write(remote.content)
-            if int(remote.headers['content-length']) == os.stat(local).st_size:
-                self.probe_timestamp(self.header_timestamp(remote))
-                return True
-            else:
+            response = requests.get(file_url, headers = self.headers, timeput = 60, allow_redirects = True)
+            response.raise_for_status()
+
+            with open(local_path, 'wb') as audio:
+                audio.write(response.content)
+
+            expected_size = int(response.headers.get('content-length', 0))
+            actual_size = os.stat(local_path).st_size
+            if expected_size and expected_size != actual_size:
+                logger.error(f"Size mismatch: expected {expected_size}, got {actual_size}")
                 return False
+
+            return True
         except Exception as e:
             logger.exception(e)
             return False

--- a/src/radautopy/utils/ttwn.py
+++ b/src/radautopy/utils/ttwn.py
@@ -33,7 +33,7 @@ class TTWN:
         response = requests.get(url, headers = self.headers, timeout = 30)
         response.raise_for_status()
 
-        return [line.strip() for lin in response.text.splitlines() if line.strip()]
+        return [line.strip() for line in response.text.splitlines() if line.strip()]
 
     def download_file(self, file_url: str, local_path) -> bool:
         """Download an audio file from the API.
@@ -44,7 +44,7 @@ class TTWN:
         Returns True on success, False on failure.
         """
         try:
-            response = requests.get(file_url, headers = self.headers, timeput = 60, allow_redirects = True)
+            response = requests.get(file_url, headers = self.headers, timeout = 60, allow_redirects = True)
             response.raise_for_status()
 
             with open(local_path, 'wb') as audio:

--- a/src/radautopy/utils/ttwn.py
+++ b/src/radautopy/utils/ttwn.py
@@ -35,7 +35,7 @@ class TTWN:
 
         return [line.strip() for line in response.text.splitlines() if line.strip()]
 
-    def download_file(self, file_url: str, local_path) -> bool:
+    def download_file(self, file_url: str, local_path: pathlib.Path | str) -> bool:
         """Download an audio file from the API.
 
         The API returns a 302 redirect to a signed CloudFront URL.
@@ -61,7 +61,7 @@ class TTWN:
             logger.exception(e)
             return False
 
-    def validate(self):
+    def validate(self) -> None:
         """Test the API connection."""
         url = f"{self.url}/audio/{self.affiliate}/newFiles"
         response = requests.get(url, headers=self.headers, timeout=30)

--- a/src/radautopy/utils/utilities.py
+++ b/src/radautopy/utils/utilities.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+import traceback
 
 from . import LOGGER_NAME
 

--- a/src/radautopy/utils/utilities.py
+++ b/src/radautopy/utils/utilities.py
@@ -6,7 +6,7 @@ from . import LOGGER_NAME
 
 logger = logging.getLogger(LOGGER_NAME)
 
-def make_dirs(path: pathlib.Path | str):
+def make_dirs(path: pathlib.Path | str) -> pathlib.Path:
     if pathlib.Path.is_dir(path):
         logger.info(f'{path} already exists')
     else:


### PR DESCRIPTION
Updates the script according to this guide:

# Radautopy Migration Guide: TTWN HTTP to HTTPS API

## Overview

This guide covers migrating radautopy's TTWN download module from the legacy HTTP endpoint to the new HTTPS API. The new system uses API key authentication and a two-step flow that maps closely to the existing manifest-based approach.

### What's Changing

| | Old (HTTP) | New (HTTPS API) |
|---|---|---|
| **Protocol** | HTTP | HTTPS (TLS 1.2+) |
| **Authentication** | Basic Auth (username/password) | API Key (`X-API-Key` header) |
| **Step 1: File list** | `GET http://isis.totaltraffic.com/TrafficTransmitter/{affiliate}/filemanifest.txt` | `GET https://audio-api.ttwnlive.com/audio/{affiliate}/newFiles` |
| **Step 2: Download** | `GET http://isis.totaltraffic.com/TrafficTransmitter/...` (direct content) | `GET https://audio-api.ttwnlive.com/audio/{affiliate}/{filename}` (302 redirect to signed URL) |
| **"New file" detection** | Client-side timestamp comparison | Server-side (API tracks downloads per user) |

### What's NOT Changing

- The runner workflow (`perform_ttwn`) and audio processing pipeline (MP3-to-WAV conversion, CART metadata, export) remain the same.
- The cron scheduling and job configuration structure are unchanged.
- The `filemap`, `dirs`, and `email` config sections are unchanged.

---

## Prerequisites

You will receive an **API key** from your TTWN Audio account administrator. This is a long string (e.g., `sk_live_abc123...`) that authenticates your automation scripts independently from your web login credentials.

Keep this key secure. If it is compromised, contact your administrator to regenerate it.

---

## Configuration Changes

### Job Config (`~/radautopy/config/{job_name}.json`)

Replace the existing `ttwn` section:

**Old:**
```json
{
  "ttwn": {
    "url": "http://isis.totaltraffic.com/TrafficTransmitter",
    "affiliate": "YOUR_AFFILIATE",
    "username": "your_username",
    "password": "your_password"
  }
}
```

**New:**
```json
{
  "ttwn": {
    "url": "https://audio-api.ttwnlive.com",
    "affiliate": "YOUR_AFFILIATE",
    "api_key": "YOUR_API_KEY"
  }
}
```

- `url` now points to the new HTTPS API base URL.
- `api_key` replaces `username`/`password` -- sent as an `X-API-Key` header on every request.
- `affiliate` is unchanged.

---

## Code Changes

### 1. TTWN Class (`utils/ttwn.py`)

The class needs to be updated to:
- Use API key authentication instead of Basic Auth
- Send a required `User-Agent` header with the prefix `ttwn_download_script` (see below)
- Fetch the new manifest format (plain text, one URL per line)
- Follow 302 redirects when downloading files
- Remove the client-side timestamp tracking (the `newFiles` endpoint handles this server-side)

#### Constructor

**Old:**
```python
def __init__(self, url, affiliate, username, password, timestamp_dir):
    self.url = url
    self.affiliate = affiliate
    self.username = username
    self.password = password
    self.timestamp_dir = pathlib.Path(timestamp_dir)
    self.remote_date_format = "%a, %d %b %Y %H:%M:%S GMT"
    self.local_date_format = "%Y%m%d%H%M%S"
    self.manifest = self.get_remote(os.path.join(self.url, self.affiliate, 'filemanifest.txt'))
```

**New:**
```python
def __init__(self, url, affiliate, api_key):
    self.url = url
    self.affiliate = affiliate
    self.api_key = api_key
    self.headers = {
        "X-API-Key": self.api_key,
        "User-Agent": "ttwn_download_script_radautopy"
    }
```

Notes:
- `timestamp_dir` is no longer needed (server tracks download state).
- The manifest is no longer fetched in the constructor. Fetch it on demand in the runner.
- **The `User-Agent` header is required.** It must start with the prefix `ttwn_download_script`. The API uses this to distinguish automated downloads from browser downloads. Without it, the `newFiles` endpoint will keep returning the same files because the server won't mark them as downloaded. You can customize the suffix (e.g., `ttwn_download_script_radautopy_v2`).

#### Fetching the Manifest (File List)

**Old:** `get_remote()` + `get_manifest()` -- fetches `{url}/{affiliate}/filemanifest.txt` (e.g., `http://isis.totaltraffic.com/TrafficTransmitter/YOUR_AFFILIATE/filemanifest.txt`), parses `url=...` line, compares timestamps.

**New:**
```python
def get_file_urls(self):
    """Fetch the list of new file URLs from the API.

    Returns a list of download URLs (one per file), or an empty list if
    there are no new files.
    """
    url = f"{self.url}/audio/{self.affiliate}/newFiles"
    response = requests.get(url, headers=self.headers, timeout=30)
    response.raise_for_status()

    # The API returns plain text with one URL per line
    urls = [line.strip() for line in response.text.splitlines() if line.strip()]
    return urls
```

Notes:
- The `newFiles` endpoint only returns files the user hasn't downloaded yet. No client-side timestamp logic needed.
- If you want ALL files (regardless of download history), use `allFiles` instead of `newFiles`.
- The response is plain text with one URL per line. No parsing of `url=...` keys required.
- Each URL is a complete, ready-to-use download URL.

#### Downloading a File

**Old:** `get_remote(url)` returns a response object, then `download_file()` writes `response.content`.

**New:**
```python
def download_file(self, file_url, local_path):
    """Download an audio file from the API.

    The API returns a 302 redirect to a signed CloudFront URL.
    requests.get() follows this redirect automatically.

    Returns True on success, False on failure.
    """
    try:
        response = requests.get(file_url, headers=self.headers, timeout=60, allow_redirects=True)
        response.raise_for_status()

        with open(local_path, 'wb') as f:
            f.write(response.content)

        # Validate file size
        expected_size = int(response.headers.get('content-length', 0))
        actual_size = os.stat(local_path).st_size
        if expected_size and expected_size != actual_size:
            logger.error(f"Size mismatch: expected {expected_size}, got {actual_size}")
            return False

        return True
    except Exception as e:
        logger.exception(e)
        return False
```

Notes:
- `allow_redirects=True` is the default for `requests.get()`, shown here explicitly for clarity. The download endpoint returns a **302 redirect** to a time-limited CloudFront signed URL that serves the actual file.
- `requests` automatically strips the `Authorization` header on cross-origin redirects, but `X-API-Key` is a custom header that may be forwarded. This is harmless -- CloudFront ignores unrecognized headers.
- The `content-length` in the final response reflects the actual file size (from CloudFront).

#### Methods to Remove

The following methods are no longer needed and can be deleted:

- `probe_timestamp()` -- server tracks download state
- `header_timestamp()` -- no client-side timestamp comparison
- `get_manifest()` -- replaced by `get_file_urls()`
- `get_remote()` -- replaced by direct `requests.get()` calls with API key header

### 2. TTWN Runner (`runners/ttwn.py`)

The runner should be updated to use the new TTWN class methods:

**Old:**
```python
def perform_ttwn(config, mailer, email_bool, remote):
    timestamp = remote.probe_timestamp()
    if handle_status_code(remote.manifest.status_code, mailer):
        try:
            url = remote.get_manifest(timestamp)
        except:
            logger.critical('could not get manifest')
            mailer.p('Could not get manifest')
            mailer.send_mail(alt_subject='An error occurred')

    remote_audio = remote.get_remote(url)
    config.concat_directories_filemap()
    track = config.filemap[0]
    if handle_status_code(remote_audio.status_code, mailer):
        if remote.download_file(remote_audio, track['input_file']):
            # ... audio processing ...
```

**New:**
```python
def perform_ttwn(config, mailer, email_bool, remote):
    try:
        file_urls = remote.get_file_urls()
    except Exception as e:
        logger.critical(f'Could not get file list: {e}')
        mailer.p('Could not get file list')
        mailer.send_mail(alt_subject='An error occurred')
        return

    if not file_urls:
        logger.info('No new files available')
        return

    config.concat_directories_filemap()
    track = config.filemap[0]

    # Download the first file URL
    if remote.download_file(file_urls[0], track['input_file']):
        local_track = AudioFile(track['input_file'], track['output_file'])
        local_track.apply_metadata(track['artist'], track['title'])
        local_track.move()
        logger.info('Successfully moved audio')
    else:
        mailer.p('Download failed')
        mailer.send_mail(alt_subject='An error occurred')
```

Notes:
- The old flow was: check timestamp -> get manifest -> parse URL -> fetch audio -> download. The new flow is: get file list -> download. Much simpler.
- If your filemap has multiple entries and you expect multiple files, iterate over `file_urls` and match to filemap entries by filename (extract filename from URL with `url.rsplit('/', 1)[-1]`).

### 3. CLI Entry Point (`radauto.py`)

Update the TTWN remote initialization to match the new constructor:

**Old:**
```python
elif 'ttwn' == job_type:
    ctx.obj['remote'] = TTWN(**config.ttwn, timestamp_dir=config.dirs['audio_tmp'])
```

**New:**
```python
elif 'ttwn' == job_type:
    ctx.obj['remote'] = TTWN(**config.ttwn)
```

The `timestamp_dir` parameter is no longer needed.

### 4. Config Validation (`radauto_config.py`)

If you have config creation/validation logic for TTWN jobs, update the prompts and validation to ask for `url`, `affiliate`, and `api_key` instead of `url`, `affiliate`, `username`, `password`.

A simple validation test:
```python
def validate(self):
    """Test the API connection."""
    url = f"{self.url}/audio/{self.affiliate}/newFiles"
    response = requests.get(url, headers=self.headers, timeout=30)
    print(f"Status: {response.status_code}")
    if response.status_code == 200:
        lines = [l for l in response.text.splitlines() if l.strip()]
        print(f"Files available: {len(lines)}")
    else:
        print(f"Error: {response.text}")
```

---

## API Reference

### Get New Files (Manifest)

```
GET https://audio-api.ttwnlive.com/audio/{affiliate}/newFiles
```

**Headers:**
```
X-API-Key: your_api_key
```

**Response (200 OK):**
```
Content-Type: text/plain
Content-Disposition: attachment; filename="fileManifest.txt"

https://audio-api.ttwnlive.com/audio/YOUR_AFFILIATE/report-news.mp3
https://audio-api.ttwnlive.com/audio/YOUR_AFFILIATE/report-traffic.mp3
```

Each line is a complete download URL. An empty response means no new files are available.

**Alternative:** Replace `newFiles` with `allFiles` to get all current files regardless of download history.

**Alternative:** Append `?format=json` for a JSON response with file metadata:
```json
{
  "affiliate": "YOUR_AFFILIATE",
  "endpoint": "newFiles",
  "files": [
    {
      "fileName": "report-news.mp3",
      "lastModified": "2026-03-05T12:30:00.000Z",
      "uploadTimestamp": "2026-03-05T12:29:45.000Z",
      "size": 1048576,
      "url": "https://audio-api.ttwnlive.com/audio/YOUR_AFFILIATE/report-news.mp3"
    }
  ],
  "count": 1
}
```

### Download a File

```
GET https://audio-api.ttwnlive.com/audio/{affiliate}/{filename}
```

**Headers:**
```
X-API-Key: your_api_key
User-Agent: ttwn_download_script_radautopy
```

**Important:** The `User-Agent` must start with `ttwn_download_script`. This tells the API to mark the file as downloaded for your user, so `newFiles` won't return it again. Without this prefix, downloads still work but `newFiles` will keep returning the same files.

**Response (302 Found):**
```
Location: https://dxxxxxxx.cloudfront.net/YOUR_AFFILIATE/report-news.mp3?Expires=...&Signature=...&Key-Pair-Id=...
```

The redirect target is a time-limited signed CloudFront URL (valid for several minutes). Your HTTP client should follow this redirect automatically to receive the file content.

**Error Responses:**
- `401 Unauthorized` -- Invalid or missing API key
- `403 Forbidden` -- API key valid but no access to this affiliate
- `404 Not Found` -- Affiliate or file not found

---

## Testing

### Quick Test with curl

```bash
# 1. Test file list
curl -s -H "X-API-Key: YOUR_API_KEY" \
  "https://audio-api.ttwnlive.com/audio/YOUR_AFFILIATE/newFiles"

# 2. Test file download (follow redirects with -L, set required User-Agent with -A)
curl -L -A "ttwn_download_script_radautopy" -H "X-API-Key: YOUR_API_KEY" \
  -o test_download.mp3 \
  "https://audio-api.ttwnlive.com/audio/YOUR_AFFILIATE/filename.mp3"
```

### Quick Test with Python

```python
import requests

API_KEY = "YOUR_API_KEY"
AFFILIATE = "YOUR_AFFILIATE"
BASE_URL = "https://audio-api.ttwnlive.com"
HEADERS = {"X-API-Key": API_KEY}

# 1. Get file list
r = requests.get(f"{BASE_URL}/audio/{AFFILIATE}/newFiles", headers=HEADERS, timeout=30)
print(f"Status: {r.status_code}")
urls = [line.strip() for line in r.text.splitlines() if line.strip()]
print(f"New files: {len(urls)}")
for url in urls:
    print(f"  {url}")

# 2. Download first file
if urls:
    r = requests.get(urls[0], headers=HEADERS, timeout=60)
    filename = urls[0].rsplit("/", 1)[-1]
    with open(filename, "wb") as f:
        f.write(r.content)
    print(f"Downloaded: {filename} ({len(r.content)} bytes)")
```

---

## Migration Checklist

- [ ] Receive API key from TTWN Audio administrator
- [ ] Update job config JSON (`url`, `affiliate`, `api_key`)
- [ ] Update `utils/ttwn.py` (new constructor, `get_file_urls()`, `download_file()`)
- [ ] Update `runners/ttwn.py` (simplified flow)
- [ ] Update `radauto.py` CLI entry point (remove `timestamp_dir`)
- [ ] Update config validation/creation prompts if applicable
- [ ] Test with curl against the live API
- [ ] Test with updated radautopy against the live API
- [ ] Remove old `.timestamp` files from `audio_tmp` directory (no longer used)
- [ ] Update cron schedule if needed (no changes required if timing is unchanged)

---

## Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| `401 Unauthorized` | Invalid or missing API key | Verify `api_key` in config; contact admin if key was regenerated |
| `403 Forbidden` | API key valid but no access to affiliate | Verify `affiliate` name matches exactly (case-sensitive); contact admin to check access |
| `404 Not Found` | Affiliate doesn't exist or has no files | Verify affiliate name; check if files have been uploaded today |
| Empty manifest (no URLs) | No new files since last download | Use `allFiles` instead of `newFiles` to verify files exist; `newFiles` only returns files not yet downloaded by this API key's user |
| `newFiles` keeps returning same files | `User-Agent` header missing or wrong prefix | Ensure `User-Agent` starts with `ttwn_download_script` on download requests; without it, downloads aren't tracked |
| SSL/TLS error | Python `requests` can't verify certificate | Ensure `certifi` package is up to date: `pip install --upgrade certifi` |
| Download returns HTML/JSON instead of audio | Not following redirect | Ensure `allow_redirects=True` (default for `requests.get()`) |
| Large file download timeout | Default timeout too short | Increase timeout or use streaming: `requests.get(url, stream=True)` with chunked writes |